### PR TITLE
[36기 이주영] ADD : complete carousel function at A Calender

### DIFF
--- a/public/data/data.json
+++ b/public/data/data.json
@@ -1,6 +1,6 @@
 [
   {
-    "Monday": [
+    "Mon": [
       {
         "id": "1",
         "quantity": "20",
@@ -40,9 +40,29 @@
         "instructor": "안도현",
         "floor": "2F",
         "deadline": true
+      },
+      {
+        "id": "2",
+        "quantity": "100",
+        "startTime": "2022-09-05 16:20:00",
+        "endTime": "2022-09-05 18:50:00",
+        "classType": "hard",
+        "instructor": "안도현",
+        "floor": "2F",
+        "deadline": true
+      },
+      {
+        "id": "2",
+        "quantity": "100",
+        "startTime": "2022-09-05 16:20:00",
+        "endTime": "2022-09-05 18:50:00",
+        "classType": "hard",
+        "instructor": "안도현",
+        "floor": "2F",
+        "deadline": true
       }
     ],
-    "Tuesday": [
+    "Tue": [
       {
         "id": "1",
         "quantity": "20",
@@ -64,7 +84,7 @@
         "deadline": true
       }
     ],
-    "Wednesday": [
+    "Wed": [
       {
         "id": "1",
         "quantity": "20",
@@ -96,7 +116,7 @@
         "deadline": false
       }
     ],
-    "Thursday": [
+    "Thu": [
       {
         "id": "1",
         "quantity": "20",
@@ -118,7 +138,7 @@
         "deadline": true
       }
     ],
-    "Friday": [
+    "Fri": [
       {
         "id": "1",
         "quantity": "20",
@@ -140,7 +160,7 @@
         "deadline": true
       }
     ],
-    "Saturday": [
+    "Sat": [
       {
         "id": "1",
         "quantity": "20",
@@ -162,7 +182,7 @@
         "deadline": true
       }
     ],
-    "Sunday": [
+    "Sun": [
       {
         "id": "1",
         "quantity": "20",

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -47,6 +47,7 @@ const ModalContainer = styled.div`
 const Content = styled.p`
   font-size: 3rem;
   margin-bottom: 8rem;
+  color: black;
 `;
 const Box = styled.div`
   display: flex;

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -30,6 +30,7 @@ const Logo = styled.h1`
   padding-left: 3rem;
   position: fixed;
   left: 3rem;
+  z-index: 10000;
 `;
 
 const SubLogo = styled.span`

--- a/src/pages/Schedule/Calender/Calender.js
+++ b/src/pages/Schedule/Calender/Calender.js
@@ -1,21 +1,56 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import Day from './Date/Day';
+import Slider from 'react-slick';
+import Modal from '../../../components/Modal/Modal';
+import 'slick-carousel/slick/slick.css';
+import 'slick-carousel/slick/slick-theme.css';
 import * as S from '../StyledSchedule';
 
 const Calender = ({ classList }) => {
+  const { Mon, Tue, Wed, Thu, Fri, Sat, Sun } = classList;
+
+  const [showModal, setShowModal] = useState(false);
+  const toggleModal = () => {
+    setShowModal(prev => !prev);
+  };
+
+  const settings = {
+    slidesToShow: 5,
+    slidesToScroll: 1,
+  };
+
+  const WEEK_CLASSES = [
+    { id: 1, name: 'Mon', classList: Mon },
+    { id: 2, name: 'Tue', classList: Tue },
+    { id: 3, name: 'Wed', classList: Wed },
+    { id: 4, name: 'Thu', classList: Thu },
+    { id: 5, name: 'Fri', classList: Fri },
+    { id: 6, name: 'Sat', classList: Sat },
+    { id: 7, name: 'Sun', classList: Sun },
+  ];
+
   return (
     <Container>
       <S.MonthContainer>September 2022</S.MonthContainer>
       <S.DateContainer>
         <S.DateSubContainer>
-          <Day name=" Mon" classList={classList.Monday} />
-          <Day name=" Tue" classList={classList.Tuesday} />
-          <Day name=" Wed" classList={classList.Wednesday} />
-          <Day name=" Thur" classList={classList.Thursday} />
-          <Day name=" Friday" classList={classList.Friday} />
-          <Day name=" Saturday" classList={classList.Saturday} />
-          <Day name=" Sunday" classList={classList.Sunday} />
+          <Carousel {...settings}>
+            {WEEK_CLASSES.map(el => {
+              return (
+                <Day
+                  key={el.id}
+                  name={el.name}
+                  classList={el.classList}
+                  toggleModal={toggleModal}
+                  showModal={showModal}
+                />
+              );
+            })}
+          </Carousel>
+          {showModal && (
+            <Modal toggleModal={toggleModal} content="예약하시겠습니까?" />
+          )}
         </S.DateSubContainer>
       </S.DateContainer>
     </Container>
@@ -26,4 +61,29 @@ export default Calender;
 
 const Container = styled.div`
   width: 100%;
+`;
+
+export const Carousel = styled(Slider)`
+  .slick-next {
+    top: 2rem;
+    right: 12rem;
+    font-size: 10rem;
+
+    &::before {
+      font-size: 5rem;
+      z-index: 10000;
+    }
+  }
+  .slick-prev {
+    top: 2rem;
+    left: 5rem;
+    z-index: 1;
+
+    &::before {
+      font-size: 5rem;
+    }
+  }
+  .slick-track {
+    width: 100%;
+  }
 `;

--- a/src/pages/Schedule/Calender/Date/Class/Class.js
+++ b/src/pages/Schedule/Calender/Date/Class/Class.js
@@ -2,13 +2,7 @@ import React, { useState } from 'react';
 import Modal from '../../../../../components/Modal/Modal';
 import * as S from '../../../StyledSchedule';
 
-const Class = ({ classList }) => {
-  const [showModal, setShowModal] = useState(false);
-
-  const toggleModal = () => {
-    setShowModal(prev => !prev);
-  };
-
+const Class = ({ classList, toggleModal, showModal }) => {
   return (
     <S.ClassList>
       <S.Location>
@@ -18,9 +12,6 @@ const Class = ({ classList }) => {
           onClick={toggleModal}
           disabled={!classList.deadline}
         >
-          {showModal && (
-            <Modal toggleModal={toggleModal} content="예약하시겠습니까?" />
-          )}
           BOOK NOW
         </S.BookBtn>
       </S.Location>

--- a/src/pages/Schedule/Calender/Date/Day.js
+++ b/src/pages/Schedule/Calender/Date/Day.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import * as S from '../../StyledSchedule';
 import Class from './Class/Class';
 
-const Day = ({ name, classList }) => {
+const Day = ({ name, classList, toggleModal, showModal }) => {
   return (
     <Container>
       <S.DateLi>
@@ -12,7 +12,12 @@ const Day = ({ name, classList }) => {
           {name}
         </S.DateTitle>
         {classList?.map(classList => (
-          <Class key={classList.id} classList={classList} />
+          <Class
+            key={classList.id}
+            classList={classList}
+            toggleModal={toggleModal}
+            showModal={showModal}
+          />
         ))}
       </S.DateLi>
     </Container>

--- a/src/pages/Schedule/Dropdown.js
+++ b/src/pages/Schedule/Dropdown.js
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
+import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowDown } from '@fortawesome/free-solid-svg-icons';
 import * as S from './StyledSchedule';
-import styled from 'styled-components';
 
 const Dropdown = ({ name, type, level, handleFilter }) => {
   const [isDropdownClick, setIsDropdownClick] = useState(false);

--- a/src/pages/Schedule/Schedule.js
+++ b/src/pages/Schedule/Schedule.js
@@ -49,7 +49,8 @@ export default Schedule;
 
 const Container = styled.div`
   width: 100vw;
-  height: inherit;
+  height: auto;
+
   background-color: black;
 `;
 

--- a/src/pages/Schedule/StyledSchedule.js
+++ b/src/pages/Schedule/StyledSchedule.js
@@ -95,18 +95,19 @@ export const MonthContainer = styled.div`
   background-color: black;
   font-size: 2.6rem;
   font-weight: 800;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 `;
 
 export const DateContainer = styled.div`
-  width: 1340px;
+  width: 1500px;
   margin: 0 auto;
-  overflow-x: scroll;
+  overflow: hidden;
 `;
 
-export const DateSubContainer = styled.div`
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
-`;
+export const DateSubContainer = styled.div``;
 
 //Date
 


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
1. slick이라는 라이브러리를 사용하여 Calender에 Carousel 기능을 추가하는 것을 목표로 합니다.

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. Calender carousel 기능 추가
-> npm install react - slick-carousel 을 사용합니다
->원하는 컴포넌트로 가서 import를 해준 뒤 공식문서를 참고하여 사용법을 익혔습니다.
->styled-component로 완전히 작업하고 싶었지만 현재 방법을 찾지 못하여 nesting하여 style을 부여한 부분이 있습니다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- state 끌어올리기에 대해 더 집중하고 알게 된 기능 브랜치였습니다. carousel 기능을 추가하면서 모달창이 하위 컴포넌트에 import되어있기 때문에 carousel 안에서 보여지고  prev and next 버튼을 누를때마다 같이 움직이는 버그를 발견하게 되었습니다. 이러한 상황에서 2번째 상위 컴포넌트인 Calender 컴포넌트로 옮긴다면 문제를 해결 할 수 있지만 그렇게 되면 props를 이용하여 3단계의 컴포넌트에 불필요한 데이터를 전달해야하는 문제를 발견했습니다. 이 브랜치에선 캐러셀 기능만 추가하였고 다른 브랜치에서 Modal 창을 recoil이라는 상태관리 라이브러리를 사용하여 적용해보려고 합니다. 
<br />

## :: 기타 질문 및 특이 사항
1. 원래 Modal창은 recoil로 전역에서 상태를 관리해야하는 것이 맞는건가요? 
